### PR TITLE
feat: support secrets manager dynamic reference in more formats

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         run: ls ./dist/*.whl
       - name: Get version
         id: version
-        run: echo "${{ steps.filename.outputs.filename }}" | awk -F "-" '{print $2}'
+        run: echo "${{ steps.filename.outputs.stdout }}" | awk -F "-" '{print $2}'
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.version.outputs.version}}
+          release_name: Release ${{ steps.version.outputs.stdout }}
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+      - run: apt-get update
+      - run: apt-get install libxml2-dev libxslt1-dev python-dev
       - name: Setup Poetry
         run: pip install poetry
       - name: Install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 name: Python Build, Test and maybe Publish
+on: ['push']
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,13 @@ jobs:
         run: poetry install
       - name: Build
         run: poetry build
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - run: ls -l
+      - name: Get wheel file
+        id: filename
+        run: ls ./dist/*.whl
       - name: Get version
         id: version
-        run: ls ./dist/*.whl | awk -F "-" '{print $2}'
+        run: echo "${{ steps.filename.outputs.filename }}" | awk -F "-" '{print $2}'
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -42,4 +44,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
           asset_path: ./dist/*.whl
+          asset_name: aws_cfn_custom_resource_resolve_parser-py3-none-any.whl
           asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Python Build, Test and maybe Publish
+jobs:
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - name: Setup Poetry
+        run: pip install poetry
+      - name: Install
+        run: poetry install
+      - name: Build
+        run: poetry build
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get version
+        id: version
+        run: ls ./dist/*.whl | awk -F "-" '{print $2}'
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ steps.version.outputs.version}}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./dist/*.whl
+          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,15 @@ jobs:
         run: poetry install
       - name: Build
         run: poetry build
-      - run: ls -l
       - name: Get wheel file
-        id: filename
-        run: ls ./dist/*.whl
-      - name: Get version
-        id: version
-        run: echo "${{ steps.filename.outputs.stdout }}" | awk -F "-" '{print $2}'
+        id: wheel
+        run: |
+          filepath=`ls ./dist/*.whl`
+          filename=`basename $filepath`
+          version=`echo $filename | awk -F "-" '{print $2}'`
+          echo ::set-output name=filepath::$filepath
+          echo ::set-output name=filename::$filename
+          echo ::set-output name=version::$version
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -33,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.version.outputs.stdout }}
+          release_name: Release ${{ steps.wheel.outputs.version }}
           draft: false
           prerelease: false
       - name: Upload Release Asset
@@ -43,6 +45,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
-          asset_path: ./dist/*.whl
-          asset_name: aws_cfn_custom_resource_resolve_parser-py3-none-any.whl
+          asset_path: ${{ steps.wheel.outputs.filepath }}
+          asset_name: ${{ steps.wheel.outputs.filename }}
           asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.10'
-      - run: apt-get update
-      - run: apt-get install libxml2-dev libxslt1-dev python-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
       - name: Setup Poetry
         run: pip install poetry
       - name: Install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ on: ['push']
 jobs:
   release:
     name: Release
-    needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:

--- a/aws_cfn_custom_resource_resolve_parser/__init__.py
+++ b/aws_cfn_custom_resource_resolve_parser/__init__.py
@@ -21,12 +21,12 @@ SECRET_ARN_REGEXP = re.compile(
     r"(?P<arn>arn:(?P<partition>aws(?:-[a-z]+)?):secretsmanager:(?P<region>[a-z0-9-]+):"
     r"(?P<account_id>\d{12}):"
     r"(?:secret:(?P<secret_id>[a-z0-9A-Z-_./]+)))"
-    r"(?P<extra>(?::SecretString:(?P<secret_key>[a-z0-9A-Z-_./]+))(?::(?P<version>[a-z0-9A-Z-]+)?)?)?(?:}})"
-)
+    r"(?P<extra>(?::SecretString:(?P<secret_key>[a-z0-9A-Z-_./]+)?)"
+    r"(?::(?P<version_stage>[a-z0-9A-Z-]+)?)?(?::(?P<version_id>[a-z0-9A-Z-]+)?)?)?:?(?:}})")
 
 SECRET_NAME_REGEXP = re.compile(
     r"(?:{{resolve:secretsmanager:)(?P<name>[a-z0-9A-Z-_./]+)"
-    r"(?P<extra>(?::SecretString:(?P<secret_key>[a-z0-9A-Z-_./]+))(?:(::)(?P<version>[a-z0-9A-Z-]+)?)?)?(?:}})"
+    r"(?P<extra>(?::SecretString:(?P<secret_key>[a-z0-9A-Z-_./]+))(?:(::)(?P<version_stage>[a-z0-9A-Z-]+)?)?)?(?:}})"
 )
 
 
@@ -67,13 +67,12 @@ def parse_secret_resolve_string(resolve_str):
     secret = None
     key = None
     stage = None
+    id = None
     if SECRET_ARN_REGEXP.match(resolve_str):
         parts = SECRET_ARN_REGEXP.match(resolve_str)
         secret = parts.group("arn")
         if not secret:
             raise ValueError("Unable to find the secret ARN in", resolve_str)
-        key = parts.group("secret_key")
-        stage = parts.group("version")
     elif SECRET_NAME_REGEXP.match(resolve_str):
         parts = SECRET_NAME_REGEXP.match(resolve_str)
         secret = parts.group("name")
@@ -82,13 +81,16 @@ def parse_secret_resolve_string(resolve_str):
             "Unable to define secret ARN nor secret name from", resolve_str
         )
     if parts:
-        key = parts.group("secret_key")
-        stage = parts.group("version")
+        parts_dict = parts.groupdict()
+      
+        key = parts_dict.get("secret_key")
+        stage = parts_dict.get("version_stage")
+        id = parts_dict.get("version_id")
 
-    return secret, key, stage
+    return secret, key, stage, id
 
 
-def retrieve_secret(secret, key=None, stage=None, client=None, session=None):
+def retrieve_secret(secret, key=None, version_stage=None, version_id=None, client=None, session=None):
     """
     Function to retrieve the secret. If key is provided, attempts to return only the key value.
     If stage is provided, retrieves the secret for given stage.
@@ -109,7 +111,7 @@ def retrieve_secret(secret, key=None, stage=None, client=None, session=None):
         client = Session().client("secretsmanager")
     try:
         get_secret_value_response = client.get_secret_value(
-            SecretId=secret, VersionStage="AWSCURRENT" if not stage else stage
+            SecretId=secret, VersionId=version_id, VersionStage=version_stage
         )
         if keyisset("SecretString", get_secret_value_response):
             res = json.loads(get_secret_value_response["SecretString"])
@@ -138,5 +140,5 @@ def handle(resolve_str):
     :return:
     """
     parts = parse_secret_resolve_string(resolve_str)
-    secret = retrieve_secret(parts[0], parts[1], parts[2])
+    secret = retrieve_secret(parts[0], parts[1], parts[2], parts[3])
     return secret

--- a/aws_cfn_custom_resource_resolve_parser/__init__.py
+++ b/aws_cfn_custom_resource_resolve_parser/__init__.py
@@ -110,8 +110,13 @@ def retrieve_secret(secret, key=None, version_stage=None, version_id=None, clien
     elif not client and not session:
         client = Session().client("secretsmanager")
     try:
+        args = {}
+        if version_id: args['VersionId'] = version_id
+        if version_stage: args['VersionStage'] = version_stage
+
         get_secret_value_response = client.get_secret_value(
-            SecretId=secret, VersionId=version_id, VersionStage=version_stage
+            SecretId=secret,
+            **args
         )
         if keyisset("SecretString", get_secret_value_response):
             res = json.loads(get_secret_value_response["SecretString"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws_cfn_custom_resource_resolve_parser"
-version = "0.2.0"
+version = "0.3.0"
 description = "AWS CFN Custom Resource parser for dynamic values"
 authors = ["John Preston <john@ews-network.net>"]
 license = "MPL-2.0"
@@ -54,7 +54,7 @@ known_first_party = "kelvin"
 github_url = "https://github.com/EWS-Network/aws_cfn_custom_resource_resolve_parser"
 
 [tool.tbump.version]
-current = "0.2.0"
+current = "0.3.0"
 
 regex = '''
   (?P<major>\d+)

--- a/tests/test_aws_cfn_custom_resource_resolve_parser.py
+++ b/tests/test_aws_cfn_custom_resource_resolve_parser.py
@@ -22,6 +22,53 @@ def test_parsing_arn():
     )
     assert secret_value[1] == "BOOTSTRAP_SERVERS"
 
+def test_parsing_arn_with_key_missing_versions():
+    secret = (
+        r"{{resolve:secretsmanager:arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+        r":SecretString:BOOTSTRAP_SERVERS::}}"
+    )
+    secret_value = parse_secret_resolve_string(secret)
+    assert (
+        secret_value[0]
+        == "arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+    )
+    assert secret_value[1] == "BOOTSTRAP_SERVERS"
+
+def test_parsing_arn_with_only_version_id():
+    secret = (
+        r"{{resolve:secretsmanager:arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+        r":SecretString:::7b4bdaaa-32b5-11ed-8bdc-00051bcc25e0}}"
+    )
+    secret_value = parse_secret_resolve_string(secret)
+    assert (
+        secret_value[0]
+        == "arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+    )
+    assert secret_value[3] == "7b4bdaaa-32b5-11ed-8bdc-00051bcc25e0"
+
+def test_parsing_arn_with_missing_version_and_key():
+    secret = (
+        r"{{resolve:secretsmanager:arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+        r":SecretString:::}}"
+    )
+    secret_value = parse_secret_resolve_string(secret)
+    assert (
+        secret_value[0]
+        == "arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+    )
+
+def test_parsing_arn_with_key_and_version_stage():
+    secret = (
+        r"{{resolve:secretsmanager:arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+        r":SecretString:BOOTSTRAP_SERVERS:AWSCURRENT:}}"
+    )
+    secret_value = parse_secret_resolve_string(secret)
+    assert (
+        secret_value[0]
+        == "arn:aws:secretsmanager:eu-west-1:012345678912:secret:kafka/eu-west-1/server01"
+    )
+    assert secret_value[1] == "BOOTSTRAP_SERVERS"
+    assert secret_value[2] == "AWSCURRENT"
 
 def test_parsing_name():
     secret = r"{{resolve:secretsmanager:/kafka/eu-west-1/server01:SecretString:BOOTSTRAP_SERVERS::AWSPENDING}}"


### PR DESCRIPTION
Resolves https://github.com/EWS-Network/aws_cfn_custom_resource_resolve_parser/issues/1

The pattern for secrets manager dynamic reference allows for json-key, version-stage and version-id to be optional.  Currently regex breaks when these optional fields are missing, but colon delimiters are still present.

In addition this change adds support for version-id which was previously missing.

`{{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}`

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
